### PR TITLE
Update references for MCP23017 library name changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ Version 2
 ---------
 An improved version of this hardware and code is available as the [MCard1802ArduinoV2](https://github.com/fourstix/MCard1802ArduinoV2)
 project.  The second version uses a 16 x 2 LCD character display and Teensy 3.2 for Pixie Video.  The hardware and code design is a bit cleaner with
-the logic divided into a Front Panel Card and Daughter Card.
+the logic divided into a Front Panel Card and a Daughter Card.
 
-The Front Panel card drives the 1802 Control lines, provides serial communication, and communicates with the 1802 Membership card's data in
+The Front Panel Card drives the 1802 Control lines, provides serial communication, and communicates with the 1802 Membership card's data in
 and data out lines.  The Daughter Card, provides the video and address line logic and suppport for the MCSMP20J ROM.
-A minimum implementation can be done with a 1802 Membership Card and the Front Panel Card logic alone.
+A minimum implementation can be done with an 1802 Membership Card and the Front Panel Card logic alone.
 
 Introduction
 -------------

--- a/src/MCard1802Dual23017/MCard1802Dual23017.ino
+++ b/src/MCard1802Dual23017/MCard1802Dual23017.ino
@@ -345,7 +345,7 @@ void blankBackpack() {
 //Set all the status flags from their repective pin
 void set1802Status() {
   //Get the control line status from MCP23017
-  byte control_data = mcp2.readPort(MCP23017_PORT::B);
+  byte control_data = mcp2.readPort(MCP23017Port::B);
   boolean value = false;
 
   #if DEBUG
@@ -426,21 +426,21 @@ void setup() {
   
   //Set up first MCP23017
   mcp1.init();
-  mcp1.portMode(MCP23017_PORT::A, 0);         //Port A as output
-  mcp1.portMode(MCP23017_PORT::B, 0b11111111);//Port B as input
+  mcp1.portMode(MCP23017Port::A, 0);         //Port A as output
+  mcp1.portMode(MCP23017Port::B, 0b11111111);//Port B as input
 
   //Initialize GPIO ports
-  mcp1.writeRegister(MCP23017_REGISTER::GPIOA, 0x00);
-  mcp1.writeRegister(MCP23017_REGISTER::GPIOB, 0x00);
+  mcp1.writeRegister(MCP23017Register::GPIO_A, 0x00);
+  mcp1.writeRegister(MCP23017Register::GPIO_B, 0x00);
 
   //Set up second MCP23017
   mcp2.init();
-  mcp2.portMode(MCP23017_PORT::A, 0b11111111);//Port A as input
-  mcp2.portMode(MCP23017_PORT::B, 0b11111111);//Port B as input
+  mcp2.portMode(MCP23017Port::A, 0b11111111);//Port A as input
+  mcp2.portMode(MCP23017Port::B, 0b11111111);//Port B as input
 
   //Initialize GPIO ports
-  mcp2.writeRegister(MCP23017_REGISTER::GPIOA, 0x00);
-  mcp2.writeRegister(MCP23017_REGISTER::GPIOB, 0x00);
+  mcp2.writeRegister(MCP23017Register::GPIO_A, 0x00);
+  mcp2.writeRegister(MCP23017Register::GPIO_B, 0x00);
 
   // Set up the Qwiic Keypad communication
   hexKeypad.begin();
@@ -584,7 +584,7 @@ void loop() {
       print2Hex(key_data);
       Serial.println(" to data bus.");
     #endif
-    mcp1.writeRegister(MCP23017_REGISTER::GPIOA, key_data);
+    mcp1.writeRegister(MCP23017Register::GPIO_A, key_data);
     old_key_data = key_data;
   } //if key_data != old_key_data
 
@@ -612,7 +612,7 @@ void loop() {
   //Save previous data
   old_data_bus = data_bus;
   //Read the input data
-  data_bus = mcp1.readPort(MCP23017_PORT::B);
+  data_bus = mcp1.readPort(MCP23017Port::B);
 
   #if DEBUG
     if (data_bus != old_data_bus) {
@@ -628,7 +628,7 @@ void loop() {
 
   //get the address byte for load display from Port A
   if (load_mode) {
-    load_address = mcp2.readPort(MCP23017_PORT::A);
+    load_address = mcp2.readPort(MCP23017Port::A);
     #if DEBUG
       Serial.print(F("Address byte: "));
       print2Hex(load_address);

--- a/src/MCard1802Mcp23017/MCard1802Mcp23017.ino
+++ b/src/MCard1802Mcp23017/MCard1802Mcp23017.ino
@@ -388,12 +388,12 @@ void setup() {
   
   //Set up MCP23017
   mcp.init();
-  mcp.portMode(MCP23017_PORT::A, 0);         //Port A as ouput
-  mcp.portMode(MCP23017_PORT::B, 0b11111111);//Port B as input
+  mcp.portMode(MCP23017Port::A, 0);         //Port A as ouput
+  mcp.portMode(MCP23017Port::B, 0b11111111);//Port B as input
 
   //Initialize GPIO ports
-  mcp.writeRegister(MCP23017_REGISTER::GPIOA, 0x00);
-  mcp.writeRegister(MCP23017_REGISTER::GPIOB, 0x00);
+  mcp.writeRegister(MCP23017Register::GPIO_A, 0x00);
+  mcp.writeRegister(MCP23017Register::GPIO_B, 0x00);
 
   // Set up the Qwiic Keypad communication
   hexKeypad.begin();
@@ -502,7 +502,7 @@ void loop() {
       print2Hex(key_data);
       Serial.println(" to data bus.");
     #endif
-    mcp.writeRegister(MCP23017_REGISTER::GPIOA, key_data);
+    mcp.writeRegister(MCP23017Register::GPIO_A, key_data);
     old_key_data = key_data;
   } //if key_data != old_key_data
 
@@ -530,7 +530,7 @@ void loop() {
   //Save previous data
   old_data_bus = data_bus;
   //Read the input data
-  data_bus = mcp.readPort(MCP23017_PORT::B);
+  data_bus = mcp.readPort(MCP23017Port::B);
 
   #if DEBUG
     if (data_bus != old_data_bus) {

--- a/src/MCard1802ProgLoader/MCard1802ProgLoader.ino
+++ b/src/MCard1802ProgLoader/MCard1802ProgLoader.ino
@@ -598,7 +598,7 @@ void blankBackpack() {
 //Set all the status flags from their repective pin
 void set1802Status() {
   //Get the control line status from MCP23017
-  byte control_data = mcp2.readPort(MCP23017_PORT::B);
+  byte control_data = mcp2.readPort(MCP23017Port::B);
   boolean value = false;
 
   #if DEBUG
@@ -678,21 +678,21 @@ void setup() {
   
   //Set up first MCP23017
   mcp1.init();
-  mcp1.portMode(MCP23017_PORT::A, 0);         //Port A as output
-  mcp1.portMode(MCP23017_PORT::B, 0b11111111);//Port B as input
+  mcp1.portMode(MCP23017Port::A, 0);         //Port A as output
+  mcp1.portMode(MCP23017Port::B, 0b11111111);//Port B as input
 
   //Initialize GPIO ports
-  mcp1.writeRegister(MCP23017_REGISTER::GPIOA, 0x00);
-  mcp1.writeRegister(MCP23017_REGISTER::GPIOB, 0x00);
+  mcp1.writeRegister(MCP23017Register::GPIO_A, 0x00);
+  mcp1.writeRegister(MCP23017Register::GPIO_B, 0x00);
 
   //Set up second MCP23017
   mcp2.init();
-  mcp2.portMode(MCP23017_PORT::A, 0b11111111);//Port A as input
-  mcp2.portMode(MCP23017_PORT::B, 0b11111111);//Port B as input
+  mcp2.portMode(MCP23017Port::A, 0b11111111);//Port A as input
+  mcp2.portMode(MCP23017Port::B, 0b11111111);//Port B as input
 
   //Initialize GPIO ports
-  mcp2.writeRegister(MCP23017_REGISTER::GPIOA, 0x00);
-  mcp2.writeRegister(MCP23017_REGISTER::GPIOB, 0x00);
+  mcp2.writeRegister(MCP23017Register::GPIO_A, 0x00);
+  mcp2.writeRegister(MCP23017Register::GPIO_B, 0x00);
 
   // Set up the Qwiic Keypad communication
   hexKeypad.begin();
@@ -837,7 +837,7 @@ void loop() {
       print2Hex(key_data);c
       Serial.println(" to data bus.");
     #endif
-    mcp1.writeRegister(MCP23017_REGISTER::GPIOA, key_data);
+    mcp1.writeRegister(MCP23017Register::GPIO_A, key_data);
     old_key_data = key_data;
   } //if key_data != old_key_data
 
@@ -904,7 +904,7 @@ void loop() {
   //Save previous data
   old_data_bus = data_bus;
   //Read the input data
-  data_bus = mcp1.readPort(MCP23017_PORT::B);
+  data_bus = mcp1.readPort(MCP23017Port::B);
 
   #if DEBUG
     if (data_bus != old_data_bus) {
@@ -920,7 +920,7 @@ void loop() {
 
   //get the address byte for load display from Port A
   if (load_mode) {
-    load_address = mcp2.readPort(MCP23017_PORT::A);
+    load_address = mcp2.readPort(MCP23017Port::A);
     #if DEBUG
       Serial.print(F("Address byte: "));
       print2Hex(load_address);


### PR DESCRIPTION
The following references were changed:

MCP23017_PORT -> MCP23017Port
MCP23017_REGISTER -> MCP23017Register
GPIOA -> GPIO_A
GPIOB -> GPIO_B